### PR TITLE
Add failing test for empty lines in <string>

### DIFF
--- a/lib/Mac/PropertyList.pm
+++ b/lib/Mac/PropertyList.pm
@@ -509,6 +509,7 @@ sub get_line {
 			}
 		else {
 			$_ = $self->get_source_line;
+			return $_;
 			}
 		}
 

--- a/t/basic_types.t
+++ b/t/basic_types.t
@@ -107,3 +107,20 @@ is_deeply(
   59,
   "basic data from a scalar",
 );
+my $string = <<'HERE';
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <string>A
+
+  new line</string>
+</plist>
+HERE
+
+is_deeply(
+  Mac::PropertyList::parse_plist($string)->as_basic_data,
+  "A
+
+  new line",
+  "basic data from a string with embedded new lines",
+);

--- a/t/basic_types.t
+++ b/t/basic_types.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 6;
 use Mac::PropertyList;
 
 my $array = <<'HERE';


### PR DESCRIPTION
**do not merge, only failing test for now**

This is just a failing test to demonstrate a problem I had reading dayone plist
entries. The <string> values there are markdown, so empty new lines are important
because the denote paragraphs etc.

I tried tracing the error as best I could, and ended up in
`Mac::PropertyList::Source::get_line`, which doesn't return empty lines back
to the caller `read_next`.
