### PR TITLE
122466: [Mac-PropertyList] Fixed parsing .plist files with XML comments.

### DIFF
--- a/lib/Mac/PropertyList.pm
+++ b/lib/Mac/PropertyList.pm
@@ -194,6 +194,7 @@ sub parse_plist {
 
 	my $plist = do {
 		if( $text =~ /\A<\?xml/ ) { # XML plists
+			$text =~ s/<!--(?:[\d\D]*?)-->//g;
 			# we can handle either 0.9 or 1.0
 			$text =~ s|^<\?xml.*?>\s*<!DOC.*>\s*<plist.*?>\s*||;
 			$text =~ s|\s*</plist>\s*$||;

--- a/plists/comments.plist
+++ b/plists/comments.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<!-- This is an above root level comment -->
+<plist version="0.9">
+<!-- This is a below root level comment -->
+<dict><!-- This is a below dict level comment -->
+	<key>NSColorPanelMode</key> 
+	<string>5</string>
+<!-- This is a below dict level comment -->
+	<key>NSDefaultOpenDirectory</key>
+	<string>/Applications/Mozilla</string>
+	<key>NSToolbar Configuration com.apple.PrefsToolbar</key>
+	<dict>
+		<key>TB Display Mode</key>
+		<integer>1</integer>
+		<key>TB Is Shown</key>
+		<integer>1</integer>
+		<key>TB Item Identifiers</key>
+		<array><!-- 1. This is a below array level comment -->
+			<string>com.apple.prefpane.showall</string>
+			<string>NSToolbarSeparatorItem</string>
+			<string>com.apple.preference.displays</string>
+			<string>com.apple.preference.sound</string>
+			<string>com.apple.preference.network</string>
+			<string>com.apple.preference.startupdisk</string>
+			<!-- 2. This is a below array level comment -->
+		</array>
+		<key>TB Size Mode</key>
+		<integer>1</integer>
+	</dict>
+	<key>NSWindow Frame NSColorPanel</key>
+	<string>3 379 205 367 0 0 1024 746 </string>
+	<key>NSWindow Frame Speech Help</key>
+	<string>233 717 444 389 0 0 1024 746 </string>
+</dict>
+</plist>


### PR DESCRIPTION
Restored removal of all XML comments (<!-- -->) from the text.

See ticket https://rt.cpan.org/Public/Bug/Display.html?id=122466 for
details.