### PR TITLE
Make cosmetic changes to tests

### DIFF
--- a/t/as_perl.t
+++ b/t/as_perl.t
@@ -52,7 +52,6 @@ my @methods = qw( as_perl );
 
 use_ok( $class ) or BAIL_OUT( "$class did not compile\n" );
 
-my $type_class = $class . '::array';
 my $parse_fqname = $class . '::parse_plist_file';
 
 my $test_file = catfile( qw( plists the_perl_review.abcdp ) );

--- a/t/import.t
+++ b/t/import.t
@@ -55,7 +55,7 @@ foreach my $name ( @subs ) {
 	ok( ! defined( &$name ), "$name is not defined yet" );
 	}
 
-Mac::PropertyList->import( ":all" );
+$class->import( ":all" );
 
 foreach my $name ( @subs ) {
 	ok( defined( &$name ), "$name is now defined yet" );


### PR DESCRIPTION
In the course of https://github.com/kulp/Mac-PropertyList-SAX/pull/4 and https://github.com/kulp/Mac-PropertyList-SAX/pull/5 I found some superficial improvements to tests.

I did not think these changes were significant enough to swamp them by adding attribution to the tests' POD, but let me know if you feel I should add myself there.

- Remove unused variable in `t/as_perl.t`
- Use $class more consistently in `t/import.t`
