### PR TITLE
Fix binary plist parsing on Windows.

### DIFF
--- a/lib/Mac/PropertyList.pm
+++ b/lib/Mac/PropertyList.pm
@@ -265,7 +265,7 @@ sub parse_plist_file {
 		return;
 		}
 
-	my $text = do { local $/; open my($fh), $file; <$fh> };
+	my $text = do { local $/; open my($fh), '<:raw', $file; <$fh> };
 
 	parse_plist( $text );
 	}


### PR DESCRIPTION
This fixes reading the binary plist on Windows by forcing the binary (raw) file mode. Prior to this fix, binary plists were either partially parsed or parsing failed completely.

This is due to the fact that reading text files on Windows is subject to automatic line-end conversion. Therefore this bug was never visible on MacOS/Linux/Unix.