### PR TITLE
Trw drop plists.t from test manifest

### DIFF
--- a/t/test_manifest
+++ b/t/test_manifest
@@ -14,6 +14,7 @@ parse_plist_fh.t
 bad_plist.t
 decode_entities.t
 write.t
+parse-timings.t
 false_key.t
 basic_types.t
 read_binary.t


### PR DESCRIPTION
As I recall, `t/plists.t` was renamed not long ago, but not dropped from `t/test_manifest`, resulting in a warning under `Test::Manifest`. I discovered this while trying to figure out why my round-trip test was not being run by GItHub actions.