### PR TITLE
Fix failure under Perl 5.43.7: calling non-existent import() with args

### DIFF
--- a/lib/Mac/PropertyList.pm
+++ b/lib/Mac/PropertyList.pm
@@ -10,7 +10,7 @@ use vars qw($ERROR);
 use Carp qw(croak carp);
 use Data::Dumper;
 use HTML::Entities;
-use XML::Entities qw(decode_entities);
+use XML::Entities;
 
 BEGIN {
 	%HTML::Entities::char2entity = %{


### PR DESCRIPTION
Perl 5.43.7 fatalized explicit imports from modules that did not have an import() method. I believe this is being changed to a warning in 5.43.8, in which case this change will quash the warning.